### PR TITLE
Fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/miekg/yamlfmt
+module github.com/wangkuiyi/yamlfmt
 
 go 1.13
 


### PR DESCRIPTION
An error when I use this with SQLFlow.org

```
go get: github.com/wangkuiyi/yamlfmt@v0.0.0-20200317071907-21a559255c34: parsing go.mod:
	module declares its path as: github.com/miekg/yamlfmt
	        but was required as: github.com/wangkuiyi/yamlfmt
```